### PR TITLE
Scope name for TXL grammar

### DIFF
--- a/txl.JSON-tmLanguage
+++ b/txl.JSON-tmLanguage
@@ -1,6 +1,6 @@
 // [PackageDev] target_format: plist, ext: tmLanguage
     { "name": "TXL",
-  "scopeName": "source.syntax_name",
+  "scopeName": "source.txl",
   "fileTypes": ["txl", "grm"],
   "uuid": "fd861065-7297-4ca1-bd27-2568e7d7a654",
 

--- a/txl.tmLanguage
+++ b/txl.tmLanguage
@@ -95,7 +95,7 @@
 		</dict>
 	</array>
 	<key>scopeName</key>
-	<string>source.syntax_name</string>
+	<string>source.txl</string>
 	<key>uuid</key>
 	<string>fd861065-7297-4ca1-bd27-2568e7d7a654</string>
 </dict>


### PR DESCRIPTION
It looks like your grammar is [missing a scope name](https://github.com/MikeHoffert/Sublime-Text-TXL-syntax/blob/master/txl.JSON-tmLanguage#L3)...?
This pull request adds source.txl as the scope name.
